### PR TITLE
Fix custom rule when the task does not exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'groovy'
 apply plugin: 'nu.studer.plugindev'
 
 group = 'com.ullink.gradle'
-version = '1.0'
+version = '1.1'
 description 'gradle-tools-plugin is a set of plugins that provide useful addition to Gradle'
 
 dependencies {

--- a/src/main/groovy/com/ullink/gradle/TaskRulesPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/TaskRulesPlugin.groovy
@@ -57,27 +57,29 @@ class TaskRulesPlugin implements Plugin<Project> {
                 orig = '' + orig.charAt(0).toLowerCase() + orig.substring(1)
                 def task = project.tasks.findByName(orig)
 
-                Map<String, ?> props = project.getProperties()
-                task.metaClass.getProperties().each() {
-                    def value = props[it.name]
-                    if (value && !Project.class.metaClass.hasProperty(null, it.name)) {
-                        if (it.type == String.class || it.type == Boolean.class || it.type == boolean.class) {
-                            println "set ${it.name} = ${value}"
-                            it.setProperty(task, value)
+                if (task) {
+                    Map<String, ?> props = project.getProperties()
+                    task.metaClass.getProperties().each() {
+                        def value = props[it.name]
+                        if (value && !Project.class.metaClass.hasProperty(null, it.name)) {
+                            if (it.type == String.class || it.type == Boolean.class || it.type == boolean.class) {
+                                println "set ${it.name} = ${value}"
+                                it.setProperty(task, value)
+                            }
+                            // TODO support other types (numbers)
                         }
-                        // TODO support other types (numbers)
                     }
+                    Map args = [dependsOn: task]
+                    Task dummyTask = project.task(args, taskName)
+                    if (extra) {
+                        def script = 'return { ' + extra + ' }'
+                        def del = Eval.me(script)
+                        del.setResolveStrategy Closure.DELEGATE_FIRST
+                        del.delegate = task
+                        del()
+                    }
+                    dummyTask
                 }
-                Map args = [dependsOn: task]
-                Task dummyTask = project.task(args, taskName)
-                if (extra) {
-                    def script = 'return { ' + extra + ' }'
-                    def del = Eval.me(script)
-                    del.setResolveStrategy Closure.DELEGATE_FIRST
-                    del.delegate = task
-                    del()
-                }
-                dummyTask
             }
         }
     }


### PR DESCRIPTION
When the task does not exist, the rule currently ends up
with a NullPointerException. Not only is it misleading but it
also is a problem when you want to run a custom task on all
subprojects of a project: some projects may not have the task
to customize. In that case we want the rule to do nothing

Also upgraded version as 1.0 was already released